### PR TITLE
Fix frontmatter YAML

### DIFF
--- a/article-extractor/SKILL.md
+++ b/article-extractor/SKILL.md
@@ -1,9 +1,7 @@
 ---
 name: article-extractor
 description: Extract clean article content from URLs (blog posts, articles, tutorials) and save as readable text. Use when user wants to download, extract, or save an article/blog post from a URL without ads, navigation, or clutter.
-allowed-tools:
-  - Bash
-  - Write
+allowed-tools: Bash,Write
 ---
 
 # Article Extractor

--- a/ship-learn-next/SKILL.md
+++ b/ship-learn-next/SKILL.md
@@ -1,9 +1,7 @@
 ---
 name: ship-learn-next
 description: Transform learning content (like YouTube transcripts, articles, tutorials) into actionable implementation plans using the Ship-Learn-Next framework. Use when user wants to turn advice, lessons, or educational content into concrete action steps, reps, or a learning quest.
-allowed-tools:
-  - Read
-  - Write
+allowed-tools: Read,Write
 ---
 
 # Ship-Learn-Next Action Planner

--- a/tapestry/SKILL.md
+++ b/tapestry/SKILL.md
@@ -1,10 +1,7 @@
 ---
 name: tapestry
 description: Unified content extraction and action planning. Use when user says "tapestry <URL>", "weave <URL>", "help me plan <URL>", "extract and plan <URL>", "make this actionable <URL>", or similar phrases indicating they want to extract content and create an action plan. Automatically detects content type (YouTube video, article, PDF) and processes accordingly.
-allowed-tools:
-  - Bash
-  - Read
-  - Write
+allowed-tools: Bash,Read,Write
 ---
 
 # Tapestry: Unified Content Extraction + Action Planning

--- a/youtube-transcript/SKILL.md
+++ b/youtube-transcript/SKILL.md
@@ -1,10 +1,7 @@
 ---
 name: youtube-transcript
 description: Download YouTube video transcripts when user provides a YouTube URL or asks to download/get/fetch a transcript from YouTube. Also use when user wants to transcribe or get captions/subtitles from a YouTube video.
-allowed-tools:
-  - Bash
-  - Read
-  - Write
+allowed-tools: Bash,Read,Write
 ---
 
 # YouTube Transcript Downloader


### PR DESCRIPTION
<img width="496" height="272" alt="Screenshot 2025-10-24 at 11 38 06" src="https://github.com/user-attachments/assets/88a070e6-a774-499e-b744-4a5ec2b4a064" />

Fixes #1 . The multi-line definition seems to break parsing. I couldn't find great examples of how this should be done, and whether Bash/Write are real tools, but at the very least Anthropic's own cookbook defines them in a single line - https://github.com/search?q=repo%3Aanthropics%2Fclaude-cookbooks%20allowed-tools&type=code