### PR TITLE
Add "Run in Smithery" badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Tapestry Skills for Claude Code
 
+[![Run in Smithery](https://smithery.ai/badge/skills/michalparkola)](https://smithery.ai/skills?ns=michalparkola&utm_source=github&utm_medium=badge)
+
+
 A collection of productivity skills for [Claude Code](https://claude.com/claude-code) that help you work faster and learn better.
 
 **Tapestry weaves learning content into action.** Extract any content (YouTube, articles, PDFs) and automatically create implementation plans.


### PR DESCRIPTION
## Add skill discoverability badge

Your 4 Claude skills are already indexed on [Smithery](https://smithery.ai), a directory of Agent Skills and MCP servers. This badge links users directly to your skills.

### Badge Preview
[![Run in Smithery](https://smithery.ai/badge/skills/michalparkola)](https://smithery.ai/skills?ns=michalparkola&utm_source=github&utm_medium=badge)

### Why add this?
- Users browsing your repo can discover and install your skills with one click
- No additional setup required - your skills are already listed

---

This is optional. Feel free to close if you prefer not to add external badges.